### PR TITLE
Fixes #4

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -53,7 +53,7 @@ rbenv_script "run-rails" do
 
   code <<-EOH
     bundle install
-    bundle exec unicorn -c /etc/unicorn.cfg -D
+    ps -p `cat /var/run/unicorn/master.pid` &>/dev/null || bundle exec unicorn -c /etc/unicorn.cfg -D
   EOH
 end
 


### PR DESCRIPTION
"vagrant provision" fails if unicorn is already running. So only run unicorn if it is not already running.
