### PR TITLE
Option to reset DB, plus set unicorn rails env

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,7 @@
 default['rails-lastmile']['app_dir'] = "/vagrant"
 default['rails-lastmile']['ruby_version'] = "1.9.3-p385"
+
+# when true, we reset the db using rake db:drop and rake db:setup
+default['rails-lastmile']['reset_db'] = false
+
+default['rails-lastmile']['environment'] = 'development'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -50,12 +50,20 @@ end
 rbenv_script "run-rails" do
   rbenv_version node['rails-lastmile']['ruby_version']
   cwd app_dir
-
-  code <<-EOH
-    bundle install
-    bundle exec rake db:migrate
-    ps -p `cat /var/run/unicorn/master.pid` &>/dev/null || bundle exec unicorn -c /etc/unicorn.cfg -D
-  EOH
+  if node['rails-lastmile']['reset_db']
+    code <<-EOT1
+      bundle install
+      bundle exec rake db:drop
+      bundle exec rake db:setup
+      ps -p `cat /var/run/unicorn/master.pid` &>/dev/null || bundle exec unicorn -c /etc/unicorn.cfg -D --env #{node['rails-lastmile']['environment']}
+    EOT1
+  else
+    code <<-EOT2
+      bundle install
+      bundle exec rake db:migrate
+      ps -p `cat /var/run/unicorn/master.pid` &>/dev/null || bundle exec unicorn -c /etc/unicorn.cfg -D --env #{node['rails-lastmile']['environment']}
+    EOT2
+  end
 end
 
 template "/etc/nginx/sites-enabled/default" do


### PR DESCRIPTION
This adds an attribute that allows db:drop then db:setup (for creating a new environment). Also adds an attribute that sets the rails env for unicorn.

The default state of each attribute means no difference in behaviour from existing rails-lastmile.

I'm using this to set up local dev envs with mysql as well as production ec2 instances with rds (using https://github.com/nrako/librarian-ec2).
