### PR TITLE
Support X-Forwarded-Proto header in nginx config

### DIFF
--- a/templates/default/nginx.erb
+++ b/templates/default/nginx.erb
@@ -1,24 +1,25 @@
-upstream unicorn {                                                                                                                                     
-  server unix:/tmp/unicorn.todo.sock fail_timeout=0;                                                                                                   
-}                                                                                                                                                      
+upstream unicorn {
+  server unix:/tmp/unicorn.todo.sock fail_timeout=0;
+}
 
-server {                                                                                                                                               
-  listen 80 default deferred;                                                                                                                          
-  # server_name example.com;                                                                                                                           
+server {
+  listen 80 default deferred;
+  # server_name example.com;
   root <%=@static_root %>;
-  try_files $uri/index.html $uri @unicorn;                                                                                                             
-  location @unicorn {                                                                                                                                  
+  try_files $uri/index.html $uri @unicorn;
+  location @unicorn {
     proxy_set_header X-Forwarded-For
-    $proxy_add_x_forwarded_for;                                                                                       
-    proxy_set_header Host $http_host;                                                                                                                  
-    proxy_redirect off;                                                                                                                                
-    proxy_pass http://unicorn;                                                                                                                         
-  }                                                                                                                                                    
-                                                                                                                                                       
-  error_page 500 502 503 504 /500.html;                                                                                                                
-  client_max_body_size 4G;                                                                                                                             
-  keepalive_timeout 10;                                                                                                                                
-} 
+    $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_pass http://unicorn;
+  }
+
+  error_page 500 502 503 504 /500.html;
+  client_max_body_size 4G;
+  keepalive_timeout 10;
+}
 
 server {
   listen 443 default_server deferred;
@@ -28,12 +29,13 @@ server {
   ssl_certificate_key /vagrant/config/certs/server.key;
 
   root <%=@static_root %>;
-  try_files $uri/index.html $uri @unicorn;                                                                                                             
-  location @unicorn {                                                                                                                                  
+  try_files $uri/index.html $uri @unicorn;
+  location @unicorn {
     proxy_set_header X-Forwarded-For
-    $proxy_add_x_forwarded_for;                                                                                       
-    proxy_set_header Host $http_host;                                                                                                                  
-    proxy_redirect off;                                                                                                                                
-    proxy_pass http://unicorn;                                                                                                                         
+    $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_pass http://unicorn;
   }
 }


### PR DESCRIPTION
Whoops. Sorry about the PR confusion. 

We ran into an issue where we did force_ssl with Rails and things started breaking. It turns out that nginx didn't know how to proxy these connections to Unicorn. This fixes that issue.
